### PR TITLE
Check if rebase is possible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aur-fetch"
-version = "0.11.2"
+version = "0.11.3"
 authors = ["morganamilo <morganamilo@gmail.com>"]
 edition = "2018"
 


### PR DESCRIPTION
There are problems in paru when installing aur packages where their repos "somehow" are in a detached head state (for example mhwd-nvidia): [issue](https://github.com/Morganamilo/paru/issues/1183)
This also happened in yay.
It was fixed by adding a `git branch --show-current` statement and check if it returns anything. If it does, a rebase is possible, else it doesn't rebase.