### PR TITLE
chore: Minor change to use https in the github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["morganamilo <morganamilo@gmail.com>"]
 edition = "2018"
 
 description = "A libary for downloading and diffing AUR packages"
-homepage = "http://github.com/Morganamilo/aur-fetch.rs"
-repository = "http://github.com/Morganamilo/aur-fetch.rs"
+homepage = "https://github.com/Morganamilo/aur-fetch.rs"
+repository = "https://github.com/Morganamilo/aur-fetch.rs"
 documentation = "https://docs.rs/aur_fetch"
 license = "GPL-3.0"
 keywords = ["archlinux", "pkgbuild", "arch", "aur"]


### PR DESCRIPTION
GitHub redirects to the address with https anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/97