### PR TITLE
fix: show diffs for first-time package clones

### DIFF
--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -578,7 +578,7 @@ fn git_has_diff<S: AsRef<OsStr>, P: AsRef<Path>>(
 
         Ok(head != upstream)
     } else {
-        Ok(false)
+        Ok(true)
     }
 }
 


### PR DESCRIPTION
git_has_diff returned false when AUR_SEEN did not exist, causing first-time clones to fall through to a directory listing instead of a diff. The diff codepath already handles missing AUR_SEEN by diffing against the empty tree, so return true to let it run.

Fixes: https://github.com/Morganamilo/paru/issues/1512